### PR TITLE
Potential fix for code scanning alert no. 1: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/src/backend/routers/auth.py
+++ b/src/backend/routers/auth.py
@@ -5,6 +5,7 @@ Authentication endpoints for the High School Management System API
 from fastapi import APIRouter, HTTPException
 from typing import Dict, Any
 import hashlib
+from argon2 import PasswordHasher
 
 from ..database import teachers_collection
 
@@ -13,20 +14,26 @@ router = APIRouter(
     tags=["auth"]
 )
 
+ph = PasswordHasher()
+
 def hash_password(password):
-    """Hash password using SHA-256"""
-    return hashlib.sha256(password.encode()).hexdigest()
+    """Hash password using Argon2"""
+    return ph.hash(password)
 
 @router.post("/login")
 def login(username: str, password: str) -> Dict[str, Any]:
     """Login a teacher account"""
     # Hash the provided password
-    hashed_password = hash_password(password)
-    
     # Find the teacher in the database
     teacher = teachers_collection.find_one({"_id": username})
     
-    if not teacher or teacher["password"] != hashed_password:
+    if not teacher:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+    
+    # Verify the password using Argon2
+    try:
+        ph.verify(teacher["password"], password)
+    except Exception:
         raise HTTPException(status_code=401, detail="Invalid username or password")
     
     # Return teacher information (excluding password)


### PR DESCRIPTION
Potential fix for [https://github.com/Texastentialist/skills-introduction-to-repository-management/security/code-scanning/1](https://github.com/Texastentialist/skills-introduction-to-repository-management/security/code-scanning/1)

To fix the problem, we should replace the use of SHA-256 for password hashing with a modern, computationally expensive password hashing algorithm. The best way to do this in Python is to use the `argon2-cffi` library, which provides the Argon2 password hashing algorithm. This algorithm automatically generates a unique salt for each password and is designed to be slow and resistant to brute-force attacks.

Specifically, we should:
- Replace the `hash_password` function to use Argon2 via `argon2.PasswordHasher`.
- Update the login logic to use Argon2's `verify` method to check the password against the stored hash.
- Add the required import for `argon2.PasswordHasher`.
- Ensure that when new passwords are set (not shown in the snippet), they are hashed using Argon2 and stored as such.

All changes are to be made in `src/backend/routers/auth.py`. We only need to update the password hashing and verification logic in the code shown.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
